### PR TITLE
Refactoring, add link shortcode, add single template

### DIFF
--- a/classes/staff_directory.php
+++ b/classes/staff_directory.php
@@ -29,6 +29,9 @@ class StaffDirectory {
 		add_action( 'init', array( 'StaffDirectory', 'init_tinymce_button' ) );
 		add_action( 'wp_ajax_get_my_form', array( 'StaffDirectory', 'thickbox_ajax_form' ) );
 		add_action( 'pre_get_posts', array( 'StaffDirectory', 'manage_listing_query' ) );
+
+        //load single-page/profile template
+        add_filter('single_template', array( 'StaffDirectory', 'load_profile_template' ) );
 	}
 
 	static function create_post_types() {
@@ -72,6 +75,28 @@ class StaffDirectory {
 			),
 		) );
 	}
+
+    static function load_profile_template($original){
+        global $post;
+        $default_file_name = 'staff_single.php';
+        if(is_singular('staff')){
+            $single_template_option = get_option('staff_single_template');
+            if(strtolower($single_template_option) == 'default'){
+                return STAFF_LIST_TEMPLATES . $default_file_name;
+            } else {
+                $template = locate_template($single_template_option);
+                if ($template && !empty($template)){
+                    return $template;
+                }
+            }
+        }
+        //Option not set to default, and template not found, try to load
+        //default anyway. This will ensure that if, somehow, the user 
+        //doesn't visit the settings page in order to instantiate the defaults,
+        //we'll still be using a template specified for staff-directory, not the
+        //default single.php
+        return STAFF_LIST_TEMPLATES . $default_file_name;
+    }
 
 	static function set_staff_admin_columns() {
 		$new_columns = array(

--- a/classes/staff_directory.php
+++ b/classes/staff_directory.php
@@ -91,7 +91,7 @@ class StaffDirectory {
             }
         }
         //Option not set to default, and template not found, try to load
-        //default anyway. This will ensure that if, somehow, the user 
+        //default anyway. This will ensure that if, somehow, the user
         //doesn't visit the settings page in order to instantiate the defaults,
         //we'll still be using a template specified for staff-directory, not the
         //default single.php

--- a/classes/staff_directory_admin.php
+++ b/classes/staff_directory_admin.php
@@ -23,6 +23,16 @@ class StaffDirectoryAdmin {
 			$staff_settings->deleteCustomTemplate( $_GET['delete-template'] );
 		}
 
+		if ( isset( $_POST['staff_single_template'] ) ) {
+            update_option( 'staff_single_template', $_POST['staff_single_template'] );
+			$did_update_options = true;
+		} else {
+            if ( get_option( 'staff_single_template' ) == '' ) {
+    			update_option( 'staff_single_template', 'default' );
+                $did_update_options = true;
+    		}
+        }
+
 		if ( isset( $_POST['staff_templates']['slug'] ) ) {
 			$staff_settings->updateDefaultStaffTemplateSlug( $_POST['staff_templates']['slug'] );
 			$did_update_options = true;

--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -1,9 +1,130 @@
 <?php
 
 class StaffDirectoryShortcode {
+
+    public static $staff_query;
+
 	static function register_shortcode() {
+        //Main shortcode to initiate plugin
 		add_shortcode( 'staff-directory', array( 'StaffDirectoryShortcode', 'shortcode' ) );
+
+        //Shortcode to initiate the loop
+        add_shortcode( 'staff_loop', array( 'StaffDirectoryShortcode', 'staff_loop_shortcode' ) );
+
+        //List of predefined shortcode tags
+        $predefined_shortcodes = array(
+            'name',
+            'name_header',
+            'photo',
+            'photo_url',
+            'bio',
+            'bio_paragraph',
+            'category'
+        );
+
+        //Add shortcodes for all $predefined_shortcodes, link to function by
+        //the name of $code_shortcode
+        foreach($predefined_shortcodes as $code){
+            add_shortcode( $code, array( 'StaffDirectoryShortcode', $code . '_shortcode' ) );
+        }
+
+        //Retrieve custom fields
+        $staff_meta_fields = get_option( 'staff_meta_fields' );
+
+        if ( !empty($staff_meta_fields) ) {
+            foreach ( $staff_meta_fields as $field ) {
+                $meta_key = $field['slug'];
+                add_shortcode( $meta_key, array( 'StaffDirectoryShortcode', 'meta_shortcode' ) );
+            }
+        }
 	}
+
+    /*** Begin shortcode functions ***/
+
+    static function meta_shortcode( $atts, $content = NULL, $tag) {
+        $meta_key             = $tag;
+        $meta_value           = get_post_meta( get_the_ID(), $meta_key, true );
+        if($meta_value) {
+            return $meta_value;
+        } else {
+            return ""; //print nothing and remove tag if no value
+        }
+
+    }
+
+    static function staff_loop_shortcode( $atts, $content = NULL ) {
+
+        $query = StaffDirectoryShortcode::$staff_query;
+        $output = "";
+
+        if ( $query->have_posts() ) {
+
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                $output .= do_shortcode($content);
+            }
+
+        }
+        return $output;
+    }
+
+    static function name_shortcode(){
+        return get_the_title();
+    }
+
+    static function name_header_shortcode(){
+        return "<h3>" . self::name_shortcode() . "</h3>";
+    }
+
+    static function photo_url_shortcode(){
+        if ( has_post_thumbnail() ) {
+            $attachment_array = wp_get_attachment_image_src( get_post_thumbnail_id() );
+            return $attachment_array[0];
+        } else {
+            return "";
+        }
+    }
+
+    static function photo_shortcode(){
+        if(!empty(self::photo_url_shortcode())){
+            return '<img src="' . self::photo_url_shortcode() . '" />';
+        } else {
+            return "";
+        }
+    }
+
+    static function bio_shortcode(){
+        return get_the_content();
+    }
+
+    static function bio_paragraph_shortcode(){
+        return "<p>" . self::bio_shortcode() . "</p>";
+    }
+
+    static function category_shortcode($atts){
+        $atts = shortcode_atts( array(
+            'all' => false,
+        ), $atts);
+        $staff_categories     = wp_get_post_terms( get_the_ID(), 'staff_category' );
+        $all_staff_categories = "";
+
+        if ( count( $staff_categories ) > 0 ) {
+            $staff_category = $staff_categories[0]->name;
+            foreach ( $staff_categories as $category ) {
+                $all_staff_categories .= $category->name . ", ";
+            }
+            $all_staff_categories = substr( $all_staff_categories, 0, strlen( $all_staff_categories ) - 2 );
+        } else {
+            $staff_category = "";
+        }
+
+        if( $atts['all'] === true ) {
+            return $all_staff_categories;
+        } else {
+            return $staff_category;
+        }
+
+    }
 
 	static function shortcode( $params ) {
 		extract( shortcode_atts( array(
@@ -28,6 +149,8 @@ class StaffDirectoryShortcode {
 
 		return StaffDirectoryShortcode::show_staff_directory( $param, $template );
 	}
+
+    /*** End shortcode functions ***/
 
 	static function show_staff_directory( $param = null, $template = null ) {
 		parse_str( $param );
@@ -69,183 +192,34 @@ class StaffDirectoryShortcode {
 			$query_args['meta_key'] = $meta_key;
 		}
 
-		$staff_query = new WP_Query( $query_args );
+        //Store in class scope so we can access query from staff_loop shortcode
+		StaffDirectoryShortcode::$staff_query = new WP_Query( $query_args );
 
-		switch ( $template ) {
-			case 'list':
-				$output = StaffDirectoryShortcode::html_for_list_template( $staff_query );
-				break;
-			case 'grid':
-				$output = StaffDirectoryShortcode::html_for_grid_template( $staff_query );
-				break;
-			default:
-				$output = StaffDirectoryShortcode::html_for_custom_template( $template, $staff_query );
-				break;
+		$output = self::retrieve_template_html($template);
 
-		}
-
-		wp_reset_query();
+        wp_reset_query();
 
 		return $output;
 	}
 
-	static function html_for_list_template( $wp_query ) {
-		$output = <<<EOT
-      <style type="text/css">
-        .clearfix {
-          clear: both;
-        }
-        .single-staff {
-          margin-bottom: 50px;
-        }
-        .single-staff .photo {
-          float: left;
-          margin-right: 15px;
-        }
-        .single-staff .photo img {
-          max-width: 100px;
-          height: auto;
-        }
-        .single-staff .name {
-          font-size: 1em;
-          line-height: 1em;
-          margin-bottom: 4px;
-        }
-        .single-staff .position {
-          font-size: .9em;
-          line-height: .9em;
-          margin-bottom: 10px;
-        }
-        .single-staff .bio {
-          margin-bottom: 8px;
-        }
-        .single-staff .email {
-          font-size: .9em;
-          line-height: .9em;
-          margin-bottom: 10px;
-        }
-        .single-staff .phone {
-          font-size: .9em;
-          line-height: .9em;
-        }
-        .single-staff .website {
-          font-size: .9em;
-          line-height: .9em;
-        }
-      </style>
-      <div id="staff-directory-wrapper">
-EOT;
-		while ( $wp_query->have_posts() ) {
-			$wp_query->the_post();
+    static function retrieve_template_html($slug) {
 
-			$name     = get_the_title();
-			$position = get_post_meta( get_the_ID(), 'position', true );
-			$bio      = get_the_content();
+        // $slug => 'File Name'
+        $template_slugs = array(
+            'grid' => 'staff_grid.php',
+            'list' => 'staff_list.php'
+        );
 
-			if ( has_post_thumbnail() ) {
-				$attachment_array = wp_get_attachment_image_src( get_post_thumbnail_id() );
-				$photo_url        = $attachment_array[0];
-				$photo_html       = '<div class="photo"><img src="' . $photo_url . '" /></div>';
-			} else {
-				$photo_html = '';
-			}
+        $cur_template = $template_slugs[$slug];
 
-			if ( get_post_meta( get_the_ID(), 'email', true ) != '' ) {
-				$email      = get_post_meta( get_the_ID(), 'email', true );
-				$email_html = '<div class="email">Email: <a href="mailto:' . $email . '">' . $email . '</a></div>';
-			} else {
-				$email_html = '';
-			}
-
-			if ( get_post_meta( get_the_ID(), 'phone', true ) != '' ) {
-				$phone_html = '<div class="phone">Phone: ' . get_post_meta( get_the_ID(), 'phone', true ) . '</div>';
-			} else {
-				$phone_html = '';
-			}
-
-			if ( get_post_meta( get_the_ID(), 'website', true ) != '' ) {
-				$website      = get_post_meta( get_the_ID(), 'website', true );
-				$website_html = '<div class="website">Website: <a href="' . $website . '">' . $website . '</a></div>';
-			} else {
-				$website_html = '';
-			}
-
-			$output .= <<<EOT
-        <div class="single-staff">
-          $photo_html
-          <div class="name">$name</div>
-          <div class="position">$position</div>
-          <div class="bio">$bio</div>
-          $email_html
-          $phone_html
-          $website_html
-          <div class="clearfix"></div>
-        </div>
-EOT;
-		}
-		$output .= "</div>";
-
-		return $output;
-	}
-
-	static function html_for_grid_template( $wp_query ) {
-		$output = <<<EOT
-      <style type="text/css">
-        .clearfix {
-          clear: both;
+        if ($cur_template) {
+            $template_contents = file_get_contents( STAFF_LIST_TEMPLATES . $cur_template);
+            return do_shortcode($template_contents);
+        } else {
+            echo $slug;
         }
-        .single-staff {
-          float: left;
-          width: 25%;
-          text-align: center;
-          padding: 0px 10px;
-        }
-        .single-staff .photo {
-          margin-bottom: 5px;
-        }
-        .single-staff .photo img {
-          max-width: 100px;
-          height: auto;
-        }
-        .single-staff .name {
-          font-size: 1em;
-          line-height: 1em;
-          margin-bottom: 4px;
-        }
-        .single-staff .position {
-          font-size: .9em;
-          line-height: .9em;
-          margin-bottom: 10px;
-        }
-      </style>
-      <div id="staff-directory-wrapper">
-EOT;
-		while ( $wp_query->have_posts() ) {
-			$wp_query->the_post();
 
-			$name     = get_the_title();
-			$position = get_post_meta( get_the_ID(), 'position', true );
-
-			if ( has_post_thumbnail() ) {
-				$attachment_array = wp_get_attachment_image_src( get_post_thumbnail_id() );
-				$photo_url        = $attachment_array[0];
-				$photo_html       = '<div class="photo"><img src="' . $photo_url . '" /></div>';
-			} else {
-				$photo_html = '';
-			}
-
-			$output .= <<<EOT
-        <div class="single-staff">
-          $photo_html
-          <div class="name">$name</div>
-          <div class="position">$position</div>
-        </div>
-EOT;
-		}
-		$output .= "</div>";
-
-		return $output;
-	}
+    }
 
 	static function html_for_custom_template( $template_slug, $wp_query ) {
 		$staff_settings = StaffSettings::sharedInstance();
@@ -265,85 +239,6 @@ EOT;
 			$output .= $before_loop_markup;
 		} else {
 			$loop_markup = $template_html;
-		}
-
-		while ( $wp_query->have_posts() ) {
-			$wp_query->the_post();
-
-			$staff_name = get_the_title();
-			if ( has_post_thumbnail() ) {
-				$attachment_array = wp_get_attachment_image_src( get_post_thumbnail_id() );
-				$photo_url        = $attachment_array[0];
-				$photo_tag        = '<img src="' . $photo_url . '" />';
-			} else {
-				$photo_url = "";
-				$photo_tag = "";
-			}
-
-			$staff_email        = get_post_meta( get_the_ID(), 'email', true );
-			$staff_email_link   = $staff_email != '' ? "<a href=\"mailto:$staff_email\">Email $staff_name</a>" : "";
-			$staff_phone_number = get_post_meta( get_the_ID(), 'phone_number', true );
-			$staff_bio          = get_the_content();
-			$staff_website      = get_post_meta( get_the_ID(), 'website', true );
-			$staff_website_link = $staff_website != '' ? "<a href=\"$staff_website\" target=\"_blank\">View website</a>" : "";
-
-			$staff_categories     = wp_get_post_terms( get_the_ID(), 'staff_category' );
-			$all_staff_categories = "";
-
-			if ( count( $staff_categories ) > 0 ) {
-				$staff_category = $staff_categories[0]->name;
-				foreach ( $staff_categories as $category ) {
-					$all_staff_categories .= $category->name . ", ";
-				}
-				$all_staff_categories = substr( $all_staff_categories, 0, strlen( $all_staff_categories ) - 2 );
-			} else {
-				$staff_category = "";
-			}
-
-			$accepted_single_tags  = array( "[name]", "[photo_url]", "[bio]", "[category]", "[category all=true]" );
-			$replace_single_values = array(
-				$staff_name,
-				$photo_url,
-				$staff_bio,
-				$staff_category,
-				$all_staff_categories
-			);
-
-			$accepted_formatted_tags  = array(
-				"[name_header]",
-				"[photo]",
-				"[email_link]",
-				"[bio_paragraph]",
-				"[website_link]"
-			);
-			$replace_formatted_values = array(
-				"<h3>$staff_name</h3>",
-				$photo_tag,
-				$staff_email_link,
-				"<p>$staff_bio</p>",
-				$staff_website_link
-			);
-
-			$current_staff_markup = str_replace( $accepted_single_tags, $replace_single_values, $loop_markup );
-			$current_staff_markup = str_replace( $accepted_formatted_tags, $replace_formatted_values, $current_staff_markup );
-
-			preg_match_all( "/\[(.*?)\]/", $current_staff_markup, $other_matches );
-			$staff_meta_fields = get_option( 'staff_meta_fields' );
-
-			if ( $staff_meta_fields != '' && count( $other_matches[0] ) > 0 ) {
-				foreach ( $other_matches[0] as $match ) {
-					foreach ( $staff_meta_fields as $field ) {
-						$meta_key                   = $field['slug'];
-						$shortcode_without_brackets = substr( $match, 1, strlen( $match ) - 2 );
-						if ( $meta_key == $shortcode_without_brackets ) {
-							$meta_value           = get_post_meta( get_the_ID(), $meta_key, true );
-							$current_staff_markup = str_replace( $match, $meta_value, $current_staff_markup );
-						}
-					}
-				}
-			}
-
-			$output .= $current_staff_markup;
 		}
 
 		if ( isset( $after_loop_markup ) ) {

--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -216,35 +216,15 @@ class StaffDirectoryShortcode {
             $template_contents = file_get_contents( STAFF_LIST_TEMPLATES . $cur_template);
             return do_shortcode($template_contents);
         } else {
-            echo $slug;
+            $staff_settings = StaffSettings::sharedInstance();
+            $output        = "";
+            $template      = $staff_settings->getCustomStaffTemplateForSlug( $slug );
+            $template_html = stripslashes( $template['html'] );
+            $template_css  = stripslashes( $template['css'] );
+
+            $output .= "<style type='text/css'>$template_css</style>";
+            $output .= do_shortcode($template_html);
+            return $output;
         }
-
     }
-
-	static function html_for_custom_template( $template_slug, $wp_query ) {
-		$staff_settings = StaffSettings::sharedInstance();
-
-		$output = '';
-
-		$template      = $staff_settings->getCustomStaffTemplateForSlug( $template_slug );
-		$template_html = stripslashes( $template['html'] );
-		$template_css  = stripslashes( $template['css'] );
-
-		$output .= "<style type=\"text/css\">$template_css</style>";
-
-		if ( strpos( $template_html, '[staff_loop]' ) ) {
-			$before_loop_markup = substr( $template_html, 0, strpos( $template_html, "[staff_loop]" ) );
-			$after_loop_markup  = substr( $template_html, strpos( $template_html, "[/staff_loop]" ) + strlen( "[/staff_loop]" ), strlen( $template_html ) - strpos( $template_html, "[/staff_loop]" ) );
-			$loop_markup        = str_replace( "[staff_loop]", "", substr( $template_html, strpos( $template_html, "[staff_loop]" ), strpos( $template_html, "[/staff_loop]" ) - strpos( $template_html, "[staff_loop]" ) ) );
-			$output .= $before_loop_markup;
-		} else {
-			$loop_markup = $template_html;
-		}
-
-		if ( isset( $after_loop_markup ) ) {
-			$output .= $after_loop_markup;
-		}
-
-		return $output;
-	}
 }

--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -19,6 +19,7 @@ class StaffDirectoryShortcode {
             'photo_url',
             'bio',
             'bio_paragraph',
+            'profile_link',
             'category'
         );
 
@@ -99,6 +100,20 @@ class StaffDirectoryShortcode {
 
     static function bio_paragraph_shortcode(){
         return "<p>" . self::bio_shortcode() . "</p>";
+    }
+
+    static function profile_link_shortcode($atts, $content = NULL){
+        $atts = shortcode_atts( array(
+            'target'     => "_self",
+            'inner_text' => "Profile"
+        ), $atts);
+        $profile_link = get_permalink( get_the_ID() );
+
+        if(!empty($content)) {
+            return "<a href='" . $profile_link . "' target='" . $atts['target'] . "'>" . do_shortcode($content) . "</a>";
+        } else {
+            return "<a href='" . $profile_link . "' target='" . $atts['target'] . "'>" . $atts['inner_text'] . "</a>";
+        }
     }
 
     static function category_shortcode($atts){

--- a/staff-directory.php
+++ b/staff-directory.php
@@ -14,6 +14,7 @@ $staff_directory_table = $wpdb->prefix . 'staff_directory';
 define( 'STAFF_DIRECTORY_TABLE', $wpdb->prefix . 'staff_directory' );
 define( 'STAFF_TEMPLATES', $wpdb->prefix . 'staff_directory_templates' );
 define( 'STAFF_PHOTOS_DIRECTORY', WP_CONTENT_DIR . "/uploads/staff-photos/" );
+define( 'STAFF_LIST_TEMPLATES', plugin_dir_path(__FILE__) . "templates/" );
 
 require_once( dirname( __FILE__ ) . '/classes/staff_settings.php' );
 

--- a/templates/staff_grid.php
+++ b/templates/staff_grid.php
@@ -1,0 +1,45 @@
+<style type="text/css">
+  .clearfix {
+    clear: both;
+  }
+  .single-staff {
+    float: left;
+    width: 25%;
+    text-align: center;
+    padding: 0px 10px;
+  }
+  .single-staff .photo {
+    margin-bottom: 5px;
+  }
+  .single-staff .photo img {
+    max-width: 100px;
+    height: auto;
+  }
+  .single-staff .name {
+    font-size: 1em;
+    line-height: 1em;
+    margin-bottom: 4px;
+  }
+  .single-staff .position {
+    font-size: .9em;
+    line-height: .9em;
+    margin-bottom: 10px;
+  }
+</style>
+<div id="staff-directory-wrapper">
+
+    [staff_loop]
+
+        <div class="single-staff">
+                [photo]
+            <div class="name">
+                [name]
+            </div>
+            <div class="position">
+                [position]
+            </div>
+        </div>
+
+    [/staff_loop]
+
+</div>

--- a/templates/staff_list.php
+++ b/templates/staff_list.php
@@ -1,0 +1,66 @@
+<style type="text/css">
+  .clearfix {
+    clear: both;
+  }
+  .single-staff {
+    margin-bottom: 50px;
+  }
+  .single-staff .photo {
+    float: left;
+    margin-right: 15px;
+  }
+  .single-staff .photo img {
+    max-width: 100px;
+    height: auto;
+  }
+  .single-staff .name {
+    font-size: 1em;
+    line-height: 1em;
+    margin-bottom: 4px;
+  }
+  .single-staff .position {
+    font-size: .9em;
+    line-height: .9em;
+    margin-bottom: 10px;
+  }
+  .single-staff .bio {
+    margin-bottom: 8px;
+  }
+  .single-staff .email {
+    font-size: .9em;
+    line-height: .9em;
+    margin-bottom: 10px;
+  }
+  .single-staff .phone {
+    font-size: .9em;
+    line-height: .9em;
+  }
+  .single-staff .website {
+    font-size: .9em;
+    line-height: .9em;
+  }
+</style>
+<div id="staff-directory-wrapper">
+
+    [staff_loop]
+
+        <div class="single-staff">
+                [photo]
+            <div class="name">
+                [name]
+            </div>
+            <div class="position">
+                [position]
+            </div>
+            <div class="bio">
+                [bio]
+            </div>
+                [email]
+                [phone_number]
+                [website]
+            <div class="clearfix"></div>
+        </div>
+
+    [/staff_loop]
+
+</div>

--- a/templates/staff_single.php
+++ b/templates/staff_single.php
@@ -1,0 +1,73 @@
+<?php get_header(); ?>
+
+			<div id="content">
+
+				<div id="inner-content" class="wrap cf">
+
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+
+						<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+
+                            <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemprop="blogPost" itemtype="http://schema.org/BlogPosting">
+
+                              <header class="article-header entry-header">
+
+                                <h1 class="entry-title single-title" itemprop="headline" rel="bookmark"><?php the_title(); ?></h1>
+
+                                <p class="byline entry-meta vcard">
+
+                                  <?php printf( 'Posted %1$s %2$s',
+                                     /* the time the post was published */
+                                     '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
+                                     /* the author of the post */
+                                     '<span class="by"> by </span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+                                  ); ?>
+
+                                </p>
+
+                              </header> <?php // end article header ?>
+
+                              <section class="entry-content cf" itemprop="articleBody">
+                                <?php
+
+                                  the_content();
+
+                                ?>
+                              </section> <?php // end article section ?>
+
+                              <footer class="article-footer">
+
+                                <?php printf( 'filed under: %1$s', get_the_category_list(', ') ); ?>
+
+                                <?php the_tags( '<p class="tags"><span class="tags-title"> Tags: </span> ', ', ', '</p>' ); ?>
+
+                              </footer> <?php // end article footer ?>
+
+                              <?php //comments_template(); ?>
+
+                            </article> <?php // end article ?>
+
+						<?php endwhile; ?>
+
+						<?php else : ?>
+
+							<article id="post-not-found" class="hentry cf">
+									<header class="article-header">
+										<h1>Post not found</h1>
+									</header>
+									<section class="entry-content">
+										<p>The content you are trying to access does not seem to exist.</p>
+									</section>
+							</article>
+
+						<?php endif; ?>
+
+					</main>
+
+					<?php //get_sidebar(); ?>
+
+				</div>
+
+			</div>
+
+<?php get_footer(); ?>

--- a/views/admin_help.php
+++ b/views/admin_help.php
@@ -24,6 +24,19 @@
 </div>
 
 <div class="help-topic" id="staff-templates">
+    <h2>Staff Directory Single Profile Templates</h2>
+    <p>
+        By default, Staff Directory uses the staff_single.php file, located in the plugin's templates folder, to display individual profile data. But you may create your own templates if you wish.
+    </p>
+    <p>
+        Warning: Do not edit the staff_single.php file directly. If you do, your changes will be overwritten when Staff Directory updates.
+    </p>
+    <p>
+        To create a custom profile template, the easiest way would be to either copy your single.php file, or to copy the staff_single.php file. Once copied, place the file in your theme's template directory (for most themes this is simply your themes main folder), and then give the file any name you choose, making sure to prefix the name with 'staff_single_' ( i.e. staff_single_myCustomTemplate.php ). If you do not use the prefix 'staff_single_', Staff Directory will not recognize your template.
+    </p>
+</div>
+
+<div class="help-topic" id="staff-templates">
   <h2>Staff Directory Templates</h2>
 
   <p>
@@ -56,8 +69,13 @@
     <li><code>[bio_paragraph]</code> - the staff member's bio with &lt;p&gt; tags</li>
     <li><code>[category]</code> - the staff member's category (first category only)</li>
     <li><code>[category all=true]</code> - all of the staff member's categories in a comma-separated list</li>
-    <li><code>[email_link]</code> (deprecated, requires and Email field above)</li>
-    <li><code>[website_link]</code> (deprecated, requires a Website field above)</li>
+    <li><code>[profile_link]</code> - wrapper or standalone - creates a link to the staff member's profile
+        <ul style="text-indent:25px;">
+            <li>Used as a wrapper: <code>[profile_link target="_self"] Some Content [/profile_link]</code></li>
+            <li>Used standalone: <code>[profile_link inner_text="Some Text" target="_self"]</code></li>
+            <li>Notice the 'inner_text' and 'target' attributes. 'inner_text' is only available for standalone profile_link tags, while target is available for either.</li>
+        </ul>
+    </li>
   </ul>
 </div>
 

--- a/views/admin_settings.php
+++ b/views/admin_settings.php
@@ -148,11 +148,12 @@
   </div>
 
   <div class="form-group">
-    <h2>Single profile templates</h2>
 
     <p>Template instructions can be found on the <a href="<?php echo get_admin_url(); ?>edit.php?post_type=staff&page=staff-directory-help#staff-template-tags">Staff Help page</a></p>
 
-    <p>Custom templates can be created by adding a php file to your theme directory with the prefix 'staff_'.</p>
+    <h2>Single profile templates</h2>
+
+    <p>Custom templates can be created by adding a php file to your theme directory with the prefix 'staff_single_'.</p>
 
     <p>
         <select name="staff_single_template">
@@ -181,8 +182,6 @@
     </p>
 
     <h2>Staff directory list templates</h2>
-
-    <p>Template instructions can be found on the <a href="<?php echo get_admin_url(); ?>edit.php?post_type=staff&page=staff-directory-help#staff-template-tags">Staff Help page</a></p>
 
     <p>Templates can be chosen manually with the [staff-directory] shortcode (slugs shown in parentheses), or you can choose to set a default template here:</p>
 

--- a/views/admin_settings.php
+++ b/views/admin_settings.php
@@ -148,7 +148,39 @@
   </div>
 
   <div class="form-group">
-    <h2>Templates</h2>
+    <h2>Single profile templates</h2>
+
+    <p>Template instructions can be found on the <a href="<?php echo get_admin_url(); ?>edit.php?post_type=staff&page=staff-directory-help#staff-template-tags">Staff Help page</a></p>
+
+    <p>Custom templates can be created by adding a php file to your theme directory with the prefix 'staff_'.</p>
+
+    <p>
+        <select name="staff_single_template">
+            <?php
+                $val = strtolower(get_option( 'staff_single_template' ));
+
+                //May cause issues for child themes in the future, requires testing.
+                //According to https://codex.wordpress.org/Function_Reference/get_template_directory ,
+                //get_template_directory() will point to parent template directory of child themes.
+                $template_path      = get_template_directory();
+                $staff_single_files = glob($template_path . "/staff_single_*.php");
+            ?>
+            <option value="default" <?php selected( $val, 'default'); ?>>Default</option>
+            <?php
+                $output = "";
+                foreach($staff_single_files as $choice) {
+                    if(substr($choice, 0, strlen($template_path . "/")) == $template_path . "/") {
+                        $choice = substr($choice, strlen($template_path . "/"));
+                    }
+                    $value   = ' value="' . strtolower($choice) . '" ';
+                    $output .= '<option' . $value . selected( $val, $choice) . '>' . $choice . '</option>';
+                }
+                echo $output;
+            ?>
+        </select>
+    </p>
+
+    <h2>Staff directory list templates</h2>
 
     <p>Template instructions can be found on the <a href="<?php echo get_admin_url(); ?>edit.php?post_type=staff&page=staff-directory-help#staff-template-tags">Staff Help page</a></p>
 

--- a/views/admin_settings.php
+++ b/views/admin_settings.php
@@ -155,21 +155,15 @@
     <p>Templates can be chosen manually with the [staff-directory] shortcode (slugs shown in parentheses), or you can choose to set a default template here:</p>
 
     <p>
-      <?php if($current_template == 'list'): ?>
-        <input type="radio" name="staff_templates[slug]" value="list" checked />
-      <?php else: ?>
-        <input type="radio" name="staff_templates[slug]" value="list" />
-      <?php endif; ?>
-      List (list)
+        <input type="radio" name="staff_templates[slug]" value="list"
+        <?php echo ($current_template == 'list' ? "checked" : "") ?> />
+        List (list)
     </p>
 
     <p>
-      <?php if($current_template == 'grid'): ?>
-        <input type="radio" name="staff_templates[slug]" value="grid" checked />
-      <?php else: ?>
-        <input type="radio" name="staff_templates[slug]" value="grid" />
-      <?php endif; ?>
-      Grid (grid)
+        <input type="radio" name="staff_templates[slug]" value="grid"
+        <?php echo ($current_template == 'grid' ? "checked" : "") ?> />
+        Grid (grid)
     </p>
 
     <?php foreach($custom_templates as $template): ?>

--- a/views/admin_settings.php
+++ b/views/admin_settings.php
@@ -156,13 +156,13 @@
 
     <p>
         <input type="radio" name="staff_templates[slug]" value="list"
-        <?php echo ($current_template == 'list' ? "checked" : "") ?> />
+        <?php checked( $current_template, 'list', true ); ?> />
         List (list)
     </p>
 
     <p>
         <input type="radio" name="staff_templates[slug]" value="grid"
-        <?php echo ($current_template == 'grid' ? "checked" : "") ?> />
+        <?php checked( $current_template, 'grid', true ); ?> />
         Grid (grid)
     </p>
 

--- a/views/partials/admin_custom_template.php
+++ b/views/partials/admin_custom_template.php
@@ -1,10 +1,8 @@
 <p>
-  <?php if($current_template == 'custom_' . $template['index']): ?>
-    <input type="radio" name="staff_templates[slug]" value="custom_<?php echo $template['index']; ?>" checked />
-  <?php else: ?>
-    <input type="radio" name="staff_templates[slug]" value="custom_<?php echo $template['index']; ?>">
-  <?php endif; ?>
-  Custom Template <?php echo $template['index']; ?> (<?php echo $template['slug']; ?>) <a href="#" class="fa fa-angle-down custom-template-dropdown-arrow"></a>
+  <input type="radio" name="staff_templates[slug]" value="custom_<?php echo $template['index']; ?>"
+  <?php checked( $current_template, 'custom_' . $template['index'], true ); ?> />
+  Custom Template <?php echo $template['index']; ?> (<?php echo $template['slug']; ?>)
+  <a href="#" class="fa fa-angle-down custom-template-dropdown-arrow"></a>
 </p>
 
 <div class="custom-template">


### PR DESCRIPTION
There were a few features I needed from this plugin that didn't exist, so I took the liberty of adding them. While working on the features I noticed some code that could be replaced by standard Wordpress functions. Overall, along with minor code changes and reorganization, I've added a [profile_link] tag that links to the respective profile. I've also added a new option to the settings page that allows users to select the template that they'd like to use for single profiles. The help page outlines these two features and how to use them.